### PR TITLE
optimize: improve chat example

### DIFF
--- a/examples/chat/home.html
+++ b/examples/chat/home.html
@@ -32,6 +32,7 @@ window.onload = function () {
         conn = new WebSocket("ws://localhost:8080/ws");
         conn.onclose = function (evt) {
             var item = document.createElement("div");
+            item.innerHTML = "<b>Connection closed.</b>";
             appendLog(item);
         };
         conn.onmessage = function (evt) {

--- a/examples/chat/home.html
+++ b/examples/chat/home.html
@@ -29,10 +29,9 @@ window.onload = function () {
     };
 
     if (window["WebSocket"]) {
-        conn = new WebSocket("ws://" + document.location.host + "/ws");
+        conn = new WebSocket("ws://localhost:8080/ws");
         conn.onclose = function (evt) {
             var item = document.createElement("div");
-            item.innerHTML = "<b>Connection closed.</b>";
             appendLog(item);
         };
         conn.onmessage = function (evt) {

--- a/examples/chat/main.go
+++ b/examples/chat/main.go
@@ -45,7 +45,7 @@ func main() {
 	// server.Default() creates a Hertz with recovery middleware.
 	// If you need a pure hertz, you can use server.New()
 	h := server.Default(server.WithHostPorts(addr))
-	h.LoadHTMLGlob("examples/chat/home.html")
+	h.LoadHTMLGlob("home.html")
 
 	h.GET("/", serveHome)
 	h.GET("/ws", func(c context.Context, ctx *app.RequestContext) {

--- a/examples/chat/main.go
+++ b/examples/chat/main.go
@@ -20,6 +20,9 @@ import (
 var upgrader = websocket.HertzUpgrader{
 	ReadBufferSize:  1024,
 	WriteBufferSize: 1024,
+	CheckOrigin: func(ctx *app.RequestContext) bool {
+		return true
+	},
 }
 
 var addr = ":8080"
@@ -42,7 +45,7 @@ func main() {
 	// server.Default() creates a Hertz with recovery middleware.
 	// If you need a pure hertz, you can use server.New()
 	h := server.Default(server.WithHostPorts(addr))
-	h.LoadHTMLGlob("home.html")
+	h.LoadHTMLGlob("examples/chat/home.html")
 
 	h.GET("/", serveHome)
 	h.GET("/ws", func(c context.Context, ctx *app.RequestContext) {


### PR DESCRIPTION
#### What type of PR is this?

optimize

<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### What this PR does / why we need it (English/Chinese):

<!--
The description will be attached in Release Notes, 
so please describe it from user-oriented.
-->

en: 
1. When we set it to `document.location.host`, the default built-in server port number of Goland or other Jetbrains IDEs is 63342. At this time, it cannot be accessed normally, because the port exposed on the backend is 8080. Since the frontendJust to test the service, it is better to hardcode it directly.
2. In addition, `CheckOrigin` needs to be set to `true`, otherwise an error `websocket: request origin not allowed by HertzUpgrader.CheckOrigin` will be reported.
3. It is best to change the path of the front-end page to the root path, otherwise an error will be reported when running directly.

zh: 
1. 当我们设置为 `document.location.host` 时，Goland 或者其他 Jetbrains IDE 的默认内置服务器端口号都是63342，此时是不能正常访问的，因为在后端暴露的端口为8080，既然前端只是为了测试服务，不如直接将其写死。
2. 除此之外需要将 `CheckOrigin` 设置为 `true`，否则会报错 `websocket: request origin not allowed by HertzUpgrader.CheckOrigin`。
5. 前端页面的路径最好更改为根路径，否则直接运行会报错。

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
None.